### PR TITLE
Clone using https instead of ssh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ curl -sfLo $AUTOLOAD/plug.vim --create-dirs \
 echo "done."
 
 echo -n "Installing vimrc.js... "
-git clone --quiet git@github.com:zperrault/vimrc.js.git ~/.vimrc.js
+git clone --quiet https://github.com/zperrault/vimrc.js.git ~/.vimrc.js
 echo "done."
 
 if [[ -f $VIMRC ]]; then


### PR DESCRIPTION
Turns out using the ssh url meant installation would fail
for anyone that hadn't configured ssh keys in GitHub. Using
the https link should work for those that don't even have
a GitHub account.

Thanks to @ezralalonde for pointing this out in #2.
