### PR TITLE
Remove tern_for_vim for vim users

### DIFF
--- a/vimrc.plugs
+++ b/vimrc.plugs
@@ -15,7 +15,6 @@ if has('nvim')
   Plug 'carlitux/deoplete-ternjs', { 'do': 'npm install -g tern', 'for': ['javascript', 'javascript.jsx'] }
 else
   Plug 'Valloric/YouCompleteMe', { 'do': './install.py --tern-completer' }
-  Plug 'ternjs/tern_for_vim', { 'do': 'npm install -g tern', 'for': ['javascript', 'javascript.jsx'] }
 endif
 
 " == JavaScript syntax highlighting ==


### PR DESCRIPTION
@Yabes pointed out that `tern_for_vim` isn't needed if we are using
YouCompleteMe. I removed it and tested it out on a fresh install and
he was right.

Fixes #1
