### PR TITLE
Vim/Neovim using vim-flow and install eslint globally

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -33,19 +33,30 @@ if has('nvim')
   set completeopt-=preview
 
   " == neomake/neomake ==
+  let g:flow_maker = {
+  \ 'exe': 'sh',
+  \ 'args': ['-c', g:flow_path.' check-contents < '.expand('%:p').' --json --strip-root | flow-vim-quickfix --path='.expand('%:p'), '%:p'],
+  \ 'errorformat': '%E%f:%l:%c\,%n: %m',
+  \ 'cwd': '%:p:h'
+  \ }
+
   let g:neomake_warning_sign = {
   \ 'text': 'W',
   \ 'texthl': 'WarningMsg',
   \ }
+
   let g:neomake_error_sign = {
   \ 'text': 'E',
   \ 'texthl': 'ErrorMsg',
   \ }
-  let g:neomake_javascript_enabled_makers = ['eslint', 'flow']
-  let g:neomake_jsx_enabled_makers = ['eslint', 'flow']
 
-  let g:neomake_javascript_flow_exe = g:flow_path
-  let g:neomake_jsx_flow_exe = g:flow_path
+  let g:makers = ['eslint', 'flow']
+
+  let g:neomake_javascript_enabled_makers = g:makers
+  let g:neomake_jsx_enabled_makers = g:makers
+
+  let g:neomake_javascript_flow_maker = g:flow_maker
+  let g:neomake_jsx_flow_maker = g:flow_maker
 
   autocmd! BufWritePost * Neomake
 else

--- a/vimrc.plugs
+++ b/vimrc.plugs
@@ -26,10 +26,10 @@ Plug 'mxw/vim-jsx'
 Plug 'othree/javascript-libraries-syntax.vim'
 
 " == JavaScript tools integration ==
+Plug 'flowtype/vim-flow'
 if has('nvim')
-  Plug 'neomake/neomake'
+  Plug 'neomake/neomake', { 'do': 'npm install -g eslint'}
 else
-  Plug 'scrooloose/syntastic'
-  Plug 'flowtype/vim-flow'
+  Plug 'scrooloose/syntastic', { 'do': 'npm install -g eslint'}
 endif
 

--- a/vimrc.plugs
+++ b/vimrc.plugs
@@ -1,6 +1,6 @@
 " == General editor plugins ==
 Plug 'tpope/vim-surround'
-Plug 'tpope/vim-commentary'
+Plug 'scrooloose/nerdcommenter'
 Plug 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' }
 Plug 'scrooloose/nerdtree'
 Plug 'tpope/vim-repeat'
@@ -20,6 +20,7 @@ else
 endif
 
 " == JavaScript syntax highlighting ==
+Plug 'pangloss/vim-javascript'
 Plug 'othree/yajs.vim'
 Plug 'othree/es.next.syntax.vim'
 Plug 'mxw/vim-jsx'
@@ -34,8 +35,8 @@ Plug 'cakebaker/scss-syntax.vim'
 " == JavaScript tools integration ==
 Plug 'flowtype/vim-flow'
 if has('nvim')
-  Plug 'neomake/neomake', { 'do': 'npm install -g eslint'}
+  Plug 'neomake/neomake'
 else
-  Plug 'scrooloose/syntastic', { 'do': 'npm install -g eslint'}
+  Plug 'scrooloose/syntastic'
 endif
 


### PR DESCRIPTION
**CHANGE LOG**

Moving `vim-flow` to be installed in vim and neovim, since we're using neomake with it too.
Install `eslint` with `syntastic` and `neomake` (this one fix #13)
